### PR TITLE
sasl2-sys: introduce gssapi-vendored feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
         - ubuntu-static
         - ubuntu-pkg-config
         - ubuntu-vendored
+        - ubuntu-gssapi-vendored
         - macos
         - macos-vendored
         include:
@@ -35,6 +36,10 @@ jobs:
             os: ubuntu-latest
             rust: stable
             features: vendored
+          - build: ubuntu-gssapi-vendored
+            os: ubuntu-latest
+            rust: stable
+            features: gssapi-vendored
           - build: macos
             os: macos-latest
             rust: stable

--- a/sasl2-sys/Cargo.toml
+++ b/sasl2-sys/Cargo.toml
@@ -13,6 +13,10 @@ links = "sasl2"
 
 [lib]
 
+[[test]]
+name = "plugins"
+required-features = ["vendored"]
+
 [dependencies]
 libc = "0.2.68"
 
@@ -22,10 +26,12 @@ version-sync = "0.9"
 [build-dependencies]
 cc = "1.0.50"
 duct = "0.13.3"
+krb5-src = { version = "0.1.0", optional = true }
 pkg-config = { version = "0.3.17", optional = true }
 
 [features]
 default = ["pkg-config"]
+gssapi-vendored = ["krb5-src", "vendored"]
 vendored = []
 
 [package.metadata.docs.rs]

--- a/sasl2-sys/sasl2/configure
+++ b/sasl2-sys/sasl2/configure
@@ -17123,6 +17123,48 @@ fi
   fi
 
   if test "$gss_impl" = "auto" -o "$gss_impl" = "mit"; then
+    # check for libkrb5support first
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for krb5int_getspecific in -lkrb5support" >&5
+$as_echo_n "checking for krb5int_getspecific in -lkrb5support... " >&6; }
+if ${ac_cv_lib_krb5support_krb5int_getspecific+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lkrb5support ${LIB_SOCKET} $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char krb5int_getspecific ();
+int
+main ()
+{
+return krb5int_getspecific ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_krb5support_krb5int_getspecific=yes
+else
+  ac_cv_lib_krb5support_krb5int_getspecific=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_krb5support_krb5int_getspecific" >&5
+$as_echo "$ac_cv_lib_krb5support_krb5int_getspecific" >&6; }
+if test "x$ac_cv_lib_krb5support_krb5int_getspecific" = xyes; then :
+  K5SUP=-lkrb5support K5SUPSTATIC=$gssapi_dir/libkrb5support.a
+fi
+
+
     gss_failed=0
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gss_unwrap in -lgssapi_krb5" >&5
 $as_echo_n "checking for gss_unwrap in -lgssapi_krb5... " >&6; }
@@ -17130,7 +17172,7 @@ if ${ac_cv_lib_gssapi_krb5_gss_unwrap+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lgssapi_krb5 ${GSSAPIBASE_LIBS} -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err ${LIB_SOCKET} $LIBS"
+LIBS="-lgssapi_krb5 ${GSSAPIBASE_LIBS} -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err ${K5SUP} -lresolv -ldl ${LIB_SOCKET} $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -17337,8 +17379,8 @@ fi
   fi
 
   if test "$gss_impl" = "mit"; then
-    GSSAPIBASE_LIBS="$GSSAPIBASE_LIBS -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err"
-    GSSAPIBASE_STATIC_LIBS="$GSSAPIBASE_LIBS $gssapi_dir/libgssapi_krb5.a $gssapi_dir/libkrb5.a $gssapi_dir/libk5crypto.a $gssapi_dir/libcom_err.a"
+    GSSAPIBASE_LIBS="$GSSAPIBASE_LIBS -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err ${K5SUP}"
+    GSSAPIBASE_STATIC_LIBS="$GSSAPIBASE_LIBS $gssapi_dir/libgssapi_krb5.a $gssapi_dir/libkrb5.a $gssapi_dir/libk5crypto.a $gssapi_dir/libcom_err.a ${K5SUPSTATIC}"
   elif test "$gss_impl" = "heimdal"; then
     CPPFLAGS="$CPPFLAGS"
     GSSAPIBASE_LIBS="$GSSAPIBASE_LIBS -lgssapi -lkrb5 -lasn1 -lroken ${LIB_CRYPT} ${LIB_DES} -lcom_err"

--- a/sasl2-sys/sasl2/lib/dlopen.c
+++ b/sasl2-sys/sasl2/lib/dlopen.c
@@ -56,10 +56,8 @@
 #include <sasl.h>
 #include "saslint.h"
 
-#ifndef PIC
 #include <saslplug.h>
 #include "staticopen.h"
-#endif
 
 #ifdef DO_DLOPEN
 #if HAVE_DIRENT_H
@@ -414,11 +412,9 @@ int _sasl_load_plugins(const add_plugin_list_t *entrypoints,
     DIR *dp;
     struct dirent *dir;
 #endif
-#ifndef PIC
     add_plugin_t *add_plugin;
     _sasl_plug_type type;
     _sasl_plug_rec *p;
-#endif
 
     if (! entrypoints
 	|| ! getpath_cb
@@ -429,7 +425,6 @@ int _sasl_load_plugins(const add_plugin_list_t *entrypoints,
 	|| ! verifyfile_cb->proc)
 	return SASL_BADPARAM;
 
-#ifndef PIC
     /* do all the static plugins first */
 
     for(cur_ep = entrypoints; cur_ep->entryname; cur_ep++) {
@@ -456,15 +451,8 @@ int _sasl_load_plugins(const add_plugin_list_t *entrypoints,
 	    	result = add_plugin(p->name, p->plug);
 	}
     }
-#endif /* !PIC */
 
-/* only do the following if:
- * 
- * we support dlopen()
- *  AND we are not staticly compiled
- *      OR we are staticly compiled and TRY_DLOPEN_WHEN_STATIC is defined
- */
-#if defined(DO_DLOPEN) && (defined(PIC) || (!defined(PIC) && defined(TRY_DLOPEN_WHEN_STATIC)))
+#if defined(TRY_DLOPEN_WHEN_STATIC)
     /* get the path to the plugins */
     result = ((sasl_getpath_t *)(getpath_cb->proc))(getpath_cb->context,
 						    &path);
@@ -545,7 +533,7 @@ int _sasl_load_plugins(const add_plugin_list_t *entrypoints,
 	}
 
     } while ((c!='=') && (c!=0));
-#endif /* defined(DO_DLOPEN) && (!defined(PIC) || (defined(PIC) && defined(TRY_DLOPEN_WHEN_STATIC))) */
+#endif
 
     return SASL_OK;
 }

--- a/sasl2-sys/sasl2/lib/server.c
+++ b/sasl2-sys/sasl2/lib/server.c
@@ -823,7 +823,7 @@ int sasl_server_init(const sasl_callback_t *callbacks,
     int ret;
     const sasl_callback_t *vf;
     const char *pluginfile = NULL;
-#ifdef PIC
+#if false
     sasl_getopt_t *getopt;
     void *context;
 #endif
@@ -894,7 +894,7 @@ int sasl_server_init(const sasl_callback_t *callbacks,
     /* load internal plugins */
     sasl_server_add_plugin("EXTERNAL", &external_server_plug_init);
 
-#ifdef PIC
+#if false
     /* delayed loading of plugins? (DSO only, as it doesn't
      * make much [any] sense to delay in the static library case) */
     if (_sasl_getcallback(NULL, SASL_CB_GETOPT, (sasl_callback_ft *)&getopt, &context) 

--- a/sasl2-sys/sasl2/m4/sasl2.m4
+++ b/sasl2-sys/sasl2/m4/sasl2.m4
@@ -116,9 +116,12 @@ if test "$gssapi" != no; then
   fi
 
   if test "$gss_impl" = "auto" -o "$gss_impl" = "mit"; then
+    # check for libkrb5support first
+    AC_CHECK_LIB(krb5support,krb5int_getspecific,K5SUP=-lkrb5support K5SUPSTATIC=$gssapi_dir/libkrb5support.a,,${LIB_SOCKET})
+
     gss_failed=0
     AC_CHECK_LIB(gssapi_krb5,gss_unwrap,gss_impl="mit",gss_failed=1,
-                 ${GSSAPIBASE_LIBS} -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err ${LIB_SOCKET})
+                 ${GSSAPIBASE_LIBS} -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err ${K5SUP} -lresolv -ldl ${LIB_SOCKET})
     if test "$gss_impl" != "auto" -a "$gss_failed" = "1"; then
       gss_impl="failed"
     fi
@@ -170,8 +173,8 @@ if test "$gssapi" != no; then
   fi
 
   if test "$gss_impl" = "mit"; then
-    GSSAPIBASE_LIBS="$GSSAPIBASE_LIBS -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err"
-    GSSAPIBASE_STATIC_LIBS="$GSSAPIBASE_LIBS $gssapi_dir/libgssapi_krb5.a $gssapi_dir/libkrb5.a $gssapi_dir/libk5crypto.a $gssapi_dir/libcom_err.a"
+    GSSAPIBASE_LIBS="$GSSAPIBASE_LIBS -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err ${K5SUP}"
+    GSSAPIBASE_STATIC_LIBS="$GSSAPIBASE_LIBS $gssapi_dir/libgssapi_krb5.a $gssapi_dir/libkrb5.a $gssapi_dir/libk5crypto.a $gssapi_dir/libcom_err.a ${K5SUPSTATIC}"
   elif test "$gss_impl" = "heimdal"; then
     CPPFLAGS="$CPPFLAGS"
     GSSAPIBASE_LIBS="$GSSAPIBASE_LIBS -lgssapi -lkrb5 -lasn1 -lroken ${LIB_CRYPT} ${LIB_DES} -lcom_err"

--- a/sasl2-sys/src/lib.rs
+++ b/sasl2-sys/src/lib.rs
@@ -33,6 +33,20 @@
 //!
 //! sasl2-sys is currently bundling libsasl2 [v2.1.27].
 //!
+//! When configuring the bundled library, rust-sasl is intentionally
+//! conservative in the features it enables. All optional features are disabled
+//! by default. The following Cargo features can be used to re-enable features
+//! as necessary.
+//!
+//!   * **`gssapi-vendored`** enables the GSSAPI plugin (`--enable-gssapi`) by
+//!      building and statically linking a copy of MIT's Kerberos implementation
+//!      using the [krb5-src] crate.
+//!
+//! Note that specifying any of these features implies `vendored`.
+//!
+//! The eventual goal is to expose each libsasl2 feature behind a Cargo feature
+//! of the same name. Pull requests on this front are welcomed.
+//!
 //! ## System
 //!
 //! Without the `vendored` Cargo feature, sasl2-sys will search for the libsasl2
@@ -50,6 +64,7 @@
 //! improve support for other platforms are welcome.
 //!
 //! [c-api]: https://github.com/cyrusimap/cyrus-sasl/tree/master/include
+//! [krb5-src]: https://github.com/MaterializeInc/rust-krb5-src
 //! [upstream]: https://www.cyrusimap.org/sasl
 //! [upstream-platforms]: https://www.cyrusimap.org/sasl/sasl/installation.html#supported-platforms
 //! [v2.1.27]: https://github.com/cyrusimap/cyrus-sasl/releases/tag/cyrus-sasl-2.1.27

--- a/sasl2-sys/tests/plugins.rs
+++ b/sasl2-sys/tests/plugins.rs
@@ -1,0 +1,86 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+use std::ffi::{CStr, CString};
+use std::ptr;
+
+use libc::c_void;
+use sasl2_sys::sasl::{sasl_client_init, sasl_server_init, SASL_OK};
+use sasl2_sys::saslplug::{
+    client_sasl_mechanism_t, sasl_client_plugin_info, sasl_info_callback_stage_t,
+    sasl_server_plugin_info, server_sasl_mechanism_t, SASL_INFO_LIST_END, SASL_INFO_LIST_START,
+};
+
+#[no_mangle]
+unsafe extern "C" fn client_plugin_info_callback(
+    m: *mut client_sasl_mechanism_t,
+    stage: sasl_info_callback_stage_t,
+    out: *mut c_void,
+) {
+    if stage != SASL_INFO_LIST_START && stage != SASL_INFO_LIST_END && m != ptr::null_mut() {
+        let mech_name = CStr::from_ptr((*(*m).plug).mech_name);
+        let out = out as *mut HashSet<String>;
+        (*out).insert(mech_name.to_str().unwrap().into());
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn server_plugin_info_callback(
+    m: *mut server_sasl_mechanism_t,
+    stage: sasl_info_callback_stage_t,
+    out: *mut c_void,
+) {
+    if stage != SASL_INFO_LIST_START && stage != SASL_INFO_LIST_END && m != ptr::null_mut() {
+        let mech_name = CStr::from_ptr((*(*m).plug).mech_name);
+        let out = out as *mut HashSet<String>;
+        (*out).insert(mech_name.to_str().unwrap().into());
+    }
+}
+
+#[test]
+fn test_plugin_info() {
+    let mut client_mechs = HashSet::new();
+    unsafe {
+        let res = sasl_client_init(ptr::null());
+        if res != SASL_OK {
+            panic!("failed to initialize sasl client");
+        }
+        sasl_client_plugin_info(
+            ptr::null(), // indicates interest in all plugins
+            Some(client_plugin_info_callback),
+            &mut client_mechs as *mut HashSet<String> as *mut c_void,
+        );
+    }
+    assert!(client_mechs.contains("EXTERNAL"));
+    #[cfg(feature = "gssapi-vendored")]
+    assert!(client_mechs.contains("GSSAPI"));
+
+    let mut server_mechs = HashSet::new();
+    unsafe {
+        let res = sasl_server_init(ptr::null(), CString::new("test_plugins").unwrap().as_ptr());
+        if res != SASL_OK {
+            panic!("failed to initialize sasl server");
+        }
+        sasl_server_plugin_info(
+            ptr::null(), // indicates interest in all plugins
+            Some(server_plugin_info_callback),
+            &mut server_mechs as *mut HashSet<String> as *mut c_void,
+        );
+    }
+    assert!(server_mechs.contains("EXTERNAL"));
+    #[cfg(feature = "gssapi-vendored")]
+    assert!(server_mechs.contains("GSSAPI"));
+}

--- a/sasl2-sys/tests/version.rs
+++ b/sasl2-sys/tests/version.rs
@@ -1,3 +1,18 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::ptr;

--- a/sasl2-sys/update.sh
+++ b/sasl2-sys/update.sh
@@ -24,7 +24,8 @@ tar --strip-components=1 -C sasl2 -xf sasl2.tar.gz
 rm sasl2.tar.gz sasl2.tar.gz.sig
 
 find sasl2 -name .gitignore -delete
-patch -sp1 <<EOF
+
+patch -sp1 <<'EOF'
 --- a/sasl2/configure.ac
 +++ b/sasl2/configure.ac
 @@ -69,6 +69,8 @@ AC_CANONICAL_TARGET
@@ -37,4 +38,138 @@ patch -sp1 <<EOF
 
  AC_ARG_ENABLE(cmulocal,
 EOF
+
+# TODO(benesch): why did upstream remove this necessary patch? There is no
+# justification provided in either the issue or the commit log.
+patch -Rsp1 <<'EOF'
+From 8c6ae2ccdfad00407c0e3036c97df31937b49049 Mon Sep 17 00:00:00 2001
+From: Quanah Gibson-Mount <quanah@symas.com>
+Date: Fri, 14 Jul 2017 11:34:17 -0700
+Subject: [PATCH] Fixes https://github.com/cyrusimap/cyrus-sasl/issues/440
+
+---
+ sasl2/m4/sasl2.m4 | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/sasl2/m4/sasl2.m4 b/sasl2/m4/sasl2.m4
+index 17df383b..537e2837 100644
+--- a/sasl2/m4/sasl2.m4
++++ b/sasl2/m4/sasl2.m4
+@@ -112,12 +112,9 @@ if test "$gssapi" != no; then
+   fi
+
+   if test "$gss_impl" = "auto" -o "$gss_impl" = "mit"; then
+-    # check for libkrb5support first
+-    AC_CHECK_LIB(krb5support,krb5int_getspecific,K5SUP=-lkrb5support K5SUPSTATIC=$gssapi_dir/libkrb5support.a,,${LIB_SOCKET})
+-
+     gss_failed=0
+     AC_CHECK_LIB(gssapi_krb5,gss_unwrap,gss_impl="mit",gss_failed=1,
+-                 ${GSSAPIBASE_LIBS} -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err ${K5SUP} -lresolv -ldl ${LIB_SOCKET})
++                 ${GSSAPIBASE_LIBS} -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err ${LIB_SOCKET})
+     if test "$gss_impl" != "auto" -a "$gss_failed" = "1"; then
+       gss_impl="failed"
+     fi
+@@ -169,8 +166,8 @@ if test "$gssapi" != no; then
+   fi
+
+   if test "$gss_impl" = "mit"; then
+-    GSSAPIBASE_LIBS="$GSSAPIBASE_LIBS -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err ${K5SUP}"
+-    GSSAPIBASE_STATIC_LIBS="$GSSAPIBASE_LIBS $gssapi_dir/libgssapi_krb5.a $gssapi_dir/libkrb5.a $gssapi_dir/libk5crypto.a $gssapi_dir/libcom_err.a ${K5SUPSTATIC}"
++    GSSAPIBASE_LIBS="$GSSAPIBASE_LIBS -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err"
++    GSSAPIBASE_STATIC_LIBS="$GSSAPIBASE_LIBS $gssapi_dir/libgssapi_krb5.a $gssapi_dir/libkrb5.a $gssapi_dir/libk5crypto.a $gssapi_dir/libcom_err.a"
+   elif test "$gss_impl" = "heimdal"; then
+     CPPFLAGS="$CPPFLAGS"
+     GSSAPIBASE_LIBS="$GSSAPIBASE_LIBS -lgssapi -lkrb5 -lasn1 -lroken ${LIB_CRYPT} ${LIB_DES} -lcom_err"
+EOF
+
+# Upstream incorrectly uses `ifdef PIC` to mean "building a shared library"
+# and the inverse to mean "building a static library." Rust requires that
+# we build static libraries with PIC, so we go fix up all these ifdefs
+# appropriately.
+patch -sp1 << 'EOF'
+diff --git a/sasl2/lib/dlopen.c b/sasl2/lib/dlopen.c
+index 8284cd8..cea0387 100644
+--- a/sasl2/lib/dlopen.c
++++ b/sasl2/lib/dlopen.c
+@@ -56,10 +56,8 @@
+ #include <sasl.h>
+ #include "saslint.h"
+
+-#ifndef PIC
+ #include <saslplug.h>
+ #include "staticopen.h"
+-#endif
+
+ #ifdef DO_DLOPEN
+ #if HAVE_DIRENT_H
+@@ -414,11 +412,9 @@ int _sasl_load_plugins(const add_plugin_list_t *entrypoints,
+     DIR *dp;
+     struct dirent *dir;
+ #endif
+-#ifndef PIC
+     add_plugin_t *add_plugin;
+     _sasl_plug_type type;
+     _sasl_plug_rec *p;
+-#endif
+
+     if (! entrypoints
+ 	|| ! getpath_cb
+@@ -429,7 +425,6 @@ int _sasl_load_plugins(const add_plugin_list_t *entrypoints,
+ 	|| ! verifyfile_cb->proc)
+ 	return SASL_BADPARAM;
+
+-#ifndef PIC
+     /* do all the static plugins first */
+
+     for(cur_ep = entrypoints; cur_ep->entryname; cur_ep++) {
+@@ -456,15 +451,8 @@ int _sasl_load_plugins(const add_plugin_list_t *entrypoints,
+ 	    	result = add_plugin(p->name, p->plug);
+ 	}
+     }
+-#endif /* !PIC */
+
+-/* only do the following if:
+- * 
+- * we support dlopen()
+- *  AND we are not staticly compiled
+- *      OR we are staticly compiled and TRY_DLOPEN_WHEN_STATIC is defined
+- */
+-#if defined(DO_DLOPEN) && (defined(PIC) || (!defined(PIC) && defined(TRY_DLOPEN_WHEN_STATIC)))
++#if defined(TRY_DLOPEN_WHEN_STATIC)
+     /* get the path to the plugins */
+     result = ((sasl_getpath_t *)(getpath_cb->proc))(getpath_cb->context,
+ 						    &path);
+@@ -545,7 +533,7 @@ int _sasl_load_plugins(const add_plugin_list_t *entrypoints,
+ 	}
+
+     } while ((c!='=') && (c!=0));
+-#endif /* defined(DO_DLOPEN) && (!defined(PIC) || (defined(PIC) && defined(TRY_DLOPEN_WHEN_STATIC))) */
++#endif
+
+     return SASL_OK;
+ }
+diff --git a/sasl2/lib/server.c b/sasl2/lib/server.c
+index 8d4c322..7cbd1cb 100644
+--- a/sasl2/lib/server.c
++++ b/sasl2/lib/server.c
+@@ -823,7 +823,7 @@ int sasl_server_init(const sasl_callback_t *callbacks,
+     int ret;
+     const sasl_callback_t *vf;
+     const char *pluginfile = NULL;
+-#ifdef PIC
++#if false
+     sasl_getopt_t *getopt;
+     void *context;
+ #endif
+@@ -894,7 +894,7 @@ int sasl_server_init(const sasl_callback_t *callbacks,
+     /* load internal plugins */
+     sasl_server_add_plugin("EXTERNAL", &external_server_plug_init);
+
+-#ifdef PIC
++#if false
+     /* delayed loading of plugins? (DSO only, as it doesn't
+      * make much [any] sense to delay in the static library case) */
+     if (_sasl_getcallback(NULL, SASL_CB_GETOPT, (sasl_callback_ft *)&getopt, &context)
+EOF
+
 (cd sasl2 && autoreconf -iv && rm -rf autom4te.cache)

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -13,5 +13,6 @@ sasl2-sys = { path = "../sasl2-sys", default-features = false }
 ctest = "0.2"
 
 [features]
+gssapi-vendored = ["sasl2-sys/gssapi-vendored"]
 pkg-config = ["sasl2-sys/pkg-config"]
 vendored = ["sasl2-sys/vendored"]


### PR DESCRIPTION
Allow enabling the GSSAPI plugin by building and statically linking a
copy of libkrb5, MIT's Kerberos implementation.

/cc @sploiselle 