### PR TITLE
Support custom libsasl2 installation dir

### DIFF
--- a/sasl2-sys/build.rs
+++ b/sasl2-sys/build.rs
@@ -193,10 +193,10 @@ fn find_sasl(metadata: &Metadata) {
         }
 
         let mut prefixes = vec![Path::new("/usr"), Path::new("/usr/local")];
-        let custom_prefix = env::var_os("SASL2_DIR").unwrap_or_default();
+        let custom_prefix = env::var_os("DEP_SASL2_ROOT").unwrap_or_default();
         if !custom_prefix.is_empty() {
             prefixes.insert(0, Path::new(&custom_prefix));
-            println!("cargo:rerun-if-env-changed=SASL2_DIR");
+            println!("cargo:rerun-if-env-changed=DEP_SASL2_ROOT");
         }
 
         for prefix in &prefixes {

--- a/sasl2-sys/build.rs
+++ b/sasl2-sys/build.rs
@@ -192,7 +192,7 @@ fn find_sasl(metadata: &Metadata) {
             }
         }
 
-        for prefix in &[Path::new("/usr"), Path::new("/usr/local")] {
+        for prefix in &[Path::new("/usr"), Path::new("/usr/local"), Path::new("/usr/local/musl")] {
             for lib_dir in vec![
                 prefix.join("lib"),
                 prefix.join("lib64"),

--- a/sasl2-sys/build.rs
+++ b/sasl2-sys/build.rs
@@ -192,7 +192,14 @@ fn find_sasl(metadata: &Metadata) {
             }
         }
 
-        for prefix in &[Path::new("/usr"), Path::new("/usr/local"), Path::new("/usr/local/musl")] {
+        let mut prefixes = vec![Path::new("/usr"), Path::new("/usr/local")];
+        let custom_prefix = env::var_os("SASL2_DIR").unwrap_or_default();
+        if !custom_prefix.is_empty() {
+            prefixes.insert(0, Path::new(&custom_prefix));
+            println!("cargo:rerun-if-env-changed=SASL2_DIR");
+        }
+
+        for prefix in &prefixes {
             for lib_dir in vec![
                 prefix.join("lib"),
                 prefix.join("lib64"),


### PR DESCRIPTION
I wonder if it would be possible to support custom libsasl2 installation prefix, in addition to `/usr` and `/usr/local`.

My use-case: I need to build rdkafka against x86_64-unknown-linux-musl in Docker using [rust-musl-builder](https://github.com/emk/rust-musl-builder). In order to support this, I first build libsasl2, then indicate that I want librdkafka to link libsasl2 statically at the given install path:

```Dockerfile
FROM ekidd/rust-musl-builder:nightly-2020-11-19 AS build

# Having rdkafka build its own libsasl2 (feature gssapi-vendored) doesn't work on musl!
# Build it from source and have rdkafka link it in statically.

ENV SASL2_STATIC=1 \
    DEP_SASL2_ROOT=/usr/local/musl

RUN VERS=2.1.27 && \
    cd /home/rust/libs && \
    curl -LO "https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-${VERS}/cyrus-sasl-${VERS}.tar.gz" && \
    tar xzf "cyrus-sasl-${VERS}.tar.gz" && cd "cyrus-sasl-${VERS}" && \
    CC=musl-gcc CPPFLAGS=-I/usr/local/musl/include LDFLAGS=-L/usr/local/musl/lib ./configure --prefix="${DEP_SASL2_ROOT}" \
        --enable-static --disable-shared --disable-sample --disable-checkapop --disable-cram --disable-scram --disable-digest \
        --disable-otp --disable-gssapi --disable-plain --disable-anon --with-dblib=none --with-pic CFLAGS=-fPIC \
        --host=x86_64-unknown-linux-musl && \
    make && sudo make install && \
    cd .. && rm -fR "cyrus-sasl-${VERS}" "cyrus-sasl-${VERS}.tar.gz"

...

RUN cargo build --release
```

Note that the vendored build using `gssapi-vendored` seems to fail to link, so I use this:

```toml
[dependencies]
rdkafka = { version = "0.24", features = ["cmake-build", "gssapi", "ssl-vendored"] }
```