### PR TITLE
sasl2-sys: permit customizing the system search directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to [Semantic
 Versioning].
 
+## Unreleased
+
+* When linking against a system copy of libsasl2, permit manually specifying
+  the search directory via the `SASL2_DIR`, `SASL2_LIB_DIR`, and
+  `SASL2_INCLUDE_DIR` environment variables.
+
 ## [0.1.12] - 2020-07-08
 
 * Introduce the `plain` feature to enable the PLAIN authentication method via

--- a/sasl2-sys/src/lib.rs
+++ b/sasl2-sys/src/lib.rs
@@ -56,8 +56,16 @@
 //! feature is enabled, as it is by default, pkg-config will be queried for the
 //! location of the sasl2 library.
 //!
-//! When linking against the system-provided library, dynamic linking is
-//! preferred unless the `SASL2_STATIC` variable is set.
+//! To override the automatic search, set the `SASL2_DIR` environment variable
+//! to the path of the directory containing the desired libsasl2 directory.
+//!
+//! If the layout of the libsasl2 directory is nonstandard, set the
+//! `SASL2_LIB_DIR` and `SASL2_INCLUDE_DIR` environment variables to the path of
+//! the directory containining the libsasl2 libraries and headers, respectively.
+//! These environment variables take precedence over `SASL2_DIR` if set.
+//!
+//! When linking against a system library, dynamic linking is preferred unless
+//! the `SASL2_STATIC` environment variable is set.
 //!
 //! # Platform support
 //!


### PR DESCRIPTION
When linking against a system copy of libsasl2, permit manually
specifying the search directory via the `SASL2_DIR`, `SASL2_LIB_DIR`,
and `SASL2_INCLUDE_DIR` environment variables.

Fix #23.