### PR TITLE
sasl2-sys: add scram feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,14 @@ jobs:
             os: ubuntu-latest
             rust: stable
             features: gssapi-vendored
+          - build: ubuntu-scram
+            os: ubuntu-latest
+            rust: stable
+            features: scram
+          - build: ubuntu-scram-vendored
+            os: ubuntu-latest
+            rust: stable
+            features: scram,openssl-vendored
           - build: macos
             os: macos-latest
             rust: stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to [Semantic
 Versioning].
 
+## Unreleased
+
+* Introduce the `scram` feature to enable the SCRAM authentication method via
+  the `--enable-scram` configure option. This feature requires linking against
+  OpenSSL by way of the [openssl-sys] crate. For convenience, the new
+  `openssl-vendored` feature re-exports the openssl-sys's crates `vendored`
+  feature.
+
 ## [0.1.13] - 2020-12-15
 
 * When linking against a system copy of libsasl2, permit manually specifying

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to [Semantic
 Versioning].
 
-## Unreleased
+## [0.1.14] - 2020-12-20
 
 * Introduce the `scram` feature to enable the SCRAM authentication method via
   the `--enable-scram` configure option. This feature requires linking against
@@ -112,6 +112,7 @@ Initial release.
 [0.1.11]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.10...v0.1.11
 [0.1.12]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.11...v0.1.12
 [0.1.13]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.12...v0.1.13
+[0.1.14]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.13...v0.1.14
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 ```toml
 # Cargo.toml
 [dependencies]
-sasl2-sys = "0.1.13"
+sasl2-sys = "0.1.14"
 ```
 
 [Cyrus SASL]: https://www.cyrusimap.org/sasl/
-[docs]: https://docs.rs/sasl2-sys/0.1.13/sasl2-sys
+[docs]: https://docs.rs/sasl2-sys/0.1.14/sasl2-sys

--- a/sasl2-sys/Cargo.toml
+++ b/sasl2-sys/Cargo.toml
@@ -20,6 +20,7 @@ required-features = ["vendored"]
 [dependencies]
 krb5-src = { version = "0.2.0", optional = true }
 libc = "0.2.68"
+openssl-sys = { version = "0.9.55", optional = true }
 
 [dev-dependencies]
 version-sync = "0.9"
@@ -32,7 +33,9 @@ pkg-config = { version = "0.3.17", optional = true }
 [features]
 default = ["pkg-config"]
 gssapi-vendored = ["krb5-src", "vendored"]
+openssl-vendored = ["openssl-sys/vendored"]
 plain = ["vendored"]
+scram = ["openssl-sys", "vendored"]
 vendored = []
 
 [package.metadata.docs.rs]

--- a/sasl2-sys/Cargo.toml
+++ b/sasl2-sys/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://docs.rs/sasl2-sys"
 repository = "https://github.com/MaterializeInc/rust-sasl"
 license = "Apache-2.0"
 categories = ["external-ffi-bindings"]
-version = "0.1.13"
+version = "0.1.14"
 edition = "2018"
 links = "sasl2"
 

--- a/sasl2-sys/src/lib.rs
+++ b/sasl2-sys/src/lib.rs
@@ -44,7 +44,14 @@
 //!
 //!   * **`plain`** enables the PLAIN plugin (`--enable-plain`).
 //!
+//!   * **`scram`** enables the SCRAM plugin (`--enable-scram`). This requires
+//!     linking against OpenSSL via the [openssl-sys] crate.
+//!
 //! Note that specifying any of these features implies `vendored`.
+//!
+//! For convenience, the `vendored` feature of the [openssl-sys] crate is
+//! re-exported as the `openssl-vendored` feature. This feature is unlikely to
+//! be useful unless used in conjuction with the `scram` feature.
 //!
 //! The eventual goal is to expose each libsasl2 feature behind a Cargo feature
 //! of the same name. Pull requests on this front are welcomed.
@@ -75,9 +82,13 @@
 //!
 //! [c-api]: https://github.com/cyrusimap/cyrus-sasl/tree/master/include
 //! [krb5-src]: https://github.com/MaterializeInc/rust-krb5-src
+//! [openssl-sys]: https://github.com/sfackler/rust-openssl
 //! [upstream]: https://www.cyrusimap.org/sasl
 //! [upstream-platforms]: https://www.cyrusimap.org/sasl/sasl/installation.html#supported-platforms
 //! [v2.1.27]: https://github.com/cyrusimap/cyrus-sasl/releases/tag/cyrus-sasl-2.1.27
+
+#[cfg(feature = "openssl-sys")]
+extern crate openssl_sys;
 
 pub mod hmac_md5;
 pub mod md5;

--- a/sasl2-sys/src/lib.rs
+++ b/sasl2-sys/src/lib.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 #![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
-#![doc(html_root_url = "https://docs.rs/sasl2-sys/0.1.13")]
+#![doc(html_root_url = "https://docs.rs/sasl2-sys/0.1.14")]
 
 //! Bindings to Cyrus SASL.
 //!

--- a/sasl2-sys/tests/plugins.rs
+++ b/sasl2-sys/tests/plugins.rs
@@ -69,6 +69,11 @@ fn test_plugin_info() {
     assert!(client_mechs.contains("GSSAPI"));
     #[cfg(feature = "plain")]
     assert!(client_mechs.contains("PLAIN"));
+    #[cfg(feature = "scram")]
+    {
+        assert!(client_mechs.contains("SCRAM-SHA-1"));
+        assert!(client_mechs.contains("SCRAM-SHA-256"));
+    }
 
     let mut server_mechs = HashSet::new();
     unsafe {
@@ -87,4 +92,9 @@ fn test_plugin_info() {
     assert!(server_mechs.contains("GSSAPI"));
     #[cfg(feature = "plain")]
     assert!(server_mechs.contains("PLAIN"));
+    #[cfg(feature = "scram")]
+    {
+        assert!(server_mechs.contains("SCRAM-SHA-1"));
+        assert!(server_mechs.contains("SCRAM-SHA-256"));
+    }
 }

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -14,5 +14,7 @@ ctest = "0.2"
 
 [features]
 gssapi-vendored = ["sasl2-sys/gssapi-vendored"]
+openssl-vendored = ["sasl2-sys/openssl-vendored"]
 pkg-config = ["sasl2-sys/pkg-config"]
+scram = ["sasl2-sys/scram"]
 vendored = ["sasl2-sys/vendored"]


### PR DESCRIPTION
The new `scram` feature controls whether the SCRAM plugin is enabled.