### PR TITLE
Use c_int for path constants

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to [Semantic
 Versioning].
 
+<!-- #release:next-header -->
+
+## [Unreleased] <!-- #release:date -->
+
+* Blindly assume the presence of the system libsasl2 when dynamically linking on
+  macOS without the `vendored` feature. (The check that validated the presence
+  of the system library became invalid in macOS Big Sur, and there isn't an
+  obvious replacement.)
+
 ## [0.1.16] - 2021-12-02
 
 * Update to the latest `config.guess` and `config.sub` versions. This notably
@@ -129,6 +138,8 @@ Initial release.
 [0.1.14]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.13...v0.1.14
 [0.1.15]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.14...v0.1.15
 [0.1.16]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.15...v0.1.16
+[Unreleased]: https://github.com/MaterializeInc/rust-sasl/compare/v0.1.16...HEAD
+<!-- #release:next-url -->
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,3 +134,5 @@ Initial release.
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 [crates-io-page]: https://crates.io/crates/sasl2-sys
 [libkrb5]: https://web.mit.edu/kerberos/
+[krb5-src]: https://docs.rs/krb5-src
+[openssl-sys]: https://docs.rs/openssl-sys

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,16 @@ Versioning].
   of the system library became invalid in macOS Big Sur, and there isn't an
   obvious replacement.)
 
+* **Backwards-incompatible change.** Change the type of `SASL_PATH_TYPE_PLUGIN`
+  and `SASL_PATH_TYPE_CONFIG` from `c_uint` to `c_int` to match the type of the
+  `path_type` parameter in the `sasl_set_path` function ([#34]).
+
+  Thanks, [@pbor]!
+
 ## [0.1.16] - 2021-12-02
 
 * Update to the latest `config.guess` and `config.sub` versions. This notably
   fixes compilation on some MacOS machines with the M1 CPU architecture ([#29]).
-
-[#29]: https://github.com/MaterializeInc/rust-sasl/issues/29
 
 ## [0.1.15] - 2021-11-28
 
@@ -83,11 +87,11 @@ Versioning].
 
 ## [0.1.5] - 2020-04-25
 
-* Use libc types rather than Rust types for constants (e.g., `libc::c_int`
-  rather than `i32`) to reduce the number of casts required when passing those
-  constants to other sasl2-sys functions.
+* **Backwards-incompatible change.** Use libc types rather than Rust types for
+  constants (e.g., `libc::c_int` rather than `i32`) to reduce the number of
+  casts required when passing those constants to other sasl2-sys functions.
 
-  **This is a backwards-incompatible change.**
+  Thanks, [@sandhose]!
 
 ## [0.1.4] - 2020-04-10
 
@@ -147,3 +151,9 @@ Initial release.
 [libkrb5]: https://web.mit.edu/kerberos/
 [krb5-src]: https://docs.rs/krb5-src
 [openssl-sys]: https://docs.rs/openssl-sys
+
+[#29]: https://github.com/MaterializeInc/rust-sasl/issues/29
+[#34]: https://github.com/MaterializeInc/rust-sasl/issues/34
+
+[@pbor]: https://github.com/pbor
+[@sandhose]: https://github.com/sandhose

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,25 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+pre-release-commit-message = "{{crate_name}}: release {{version}}"
+pre-release-replacements = [
+  { file="README.md", search = "sasl2-sys = .*", replace = "{{crate_name}} = \"{{version}}\"" },
+  { file="README.md", search = "docs.rs/sasl2-sys/[0-9.+]+", replace = "docs.rs/{{crate_name}}/{{version}}" },
+  { file="CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
+  { file="CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
+  { file="CHANGELOG.md", search = "<!-- #release:date -->", replace = "- {{date}}" },
+  { file="CHANGELOG.md", search = "<!-- #release:next-header -->", replace = "<!-- #release:next-header -->\n\n## [Unreleased] <!-- #release:date -->", exactly = 1 },
+  { file="CHANGELOG.md", search = "<!-- #release:next-url -->", replace = "<!-- #release:next-url -->\n[Unreleased]: https://github.com/MaterializeInc/rust-sasl/compare/{{tag_name}}...HEAD", exactly = 1 },
+]

--- a/sasl2-sys/src/sasl.rs
+++ b/sasl2-sys/src/sasl.rs
@@ -383,8 +383,8 @@ pub const SASL_CB_CANON_USER: c_ulong = 32775;
 
 // Common client/server functions.
 
-pub const SASL_PATH_TYPE_PLUGIN: c_uint = 0;
-pub const SASL_PATH_TYPE_CONFIG: c_uint = 1;
+pub const SASL_PATH_TYPE_PLUGIN: c_int = 0;
+pub const SASL_PATH_TYPE_CONFIG: c_int = 1;
 
 extern "C" {
     pub fn sasl_set_path(path_type: c_int, path: *mut c_char) -> c_int;


### PR DESCRIPTION
This is a resubmission of #33 that also includes a fix for macOS CI.

Fix #34.
Closes #33.