### PR TITLE
sasl2-sys: don't derive Copy and Clone for sasl_secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
+* Don't derive `Copy` or `Clone` for the `sasl_secret_t` type, as it represents
+  a variable-length struct whose true length is not correctly handled by the
+  auto-derived implementations of `Copy` and `Clone` ([#36]).
+
 ## [0.1.17] - 2021-12-27
 
 * Blindly assume the presence of the system libsasl2 when dynamically linking on
@@ -157,6 +161,7 @@ Initial release.
 
 [#29]: https://github.com/MaterializeInc/rust-sasl/issues/29
 [#34]: https://github.com/MaterializeInc/rust-sasl/issues/34
+[#36]: https://github.com/MaterializeInc/rust-sasl/issues/36
 
 [@pbor]: https://github.com/pbor
 [@sandhose]: https://github.com/sandhose

--- a/sasl2-sys/src/sasl.rs
+++ b/sasl2-sys/src/sasl.rs
@@ -107,7 +107,7 @@ pub type sasl_conn_t = sasl_conn;
 // Password state.
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub struct sasl_secret {
     pub len: c_ulong,
     pub data: [c_uchar; 1],


### PR DESCRIPTION
This struct represents a variable-width C struct, so the auto-derived
implementations of Copy/Clone are wrong. Just delete those
implementations.

Fix #36.