### PR TITLE
Use c_int for log level constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
+* **Backwards-incompatible change.** Change the type of the log level constants
+  constants from `c_uint` to `c_int` to match the type of the `level`
+  parameter of the `sasl_log_t` typedef ([#40]). The log level constants are:
+
+  * `SASL_LOG_NONE`
+  * `SASL_LOG_ERR`
+  * `SASL_LOG_FAIL`
+  * `SASL_LOG_WARN`
+  * `SASL_LOG_NOTE`
+  * `SASL_LOG_DEBUG`
+  * `SASL_LOG_TRACE`
+  * `SASL_LOG_PASS`
+
 * Don't derive `Copy` or `Clone` for the `sasl_secret_t` type, as it represents
   a variable-length struct whose true length is not correctly handled by the
   auto-derived implementations of `Copy` and `Clone` ([#36]).
@@ -162,6 +175,7 @@ Initial release.
 [#29]: https://github.com/MaterializeInc/rust-sasl/issues/29
 [#34]: https://github.com/MaterializeInc/rust-sasl/issues/34
 [#36]: https://github.com/MaterializeInc/rust-sasl/issues/36
+[#40]: https://github.com/MaterializeInc/rust-sasl/issues/40
 
 [@pbor]: https://github.com/pbor
 [@sandhose]: https://github.com/sandhose

--- a/sasl2-sys/src/sasl.rs
+++ b/sasl2-sys/src/sasl.rs
@@ -221,14 +221,14 @@ pub type sasl_getopt_t = Option<
 
 pub const SASL_CB_GETOPT: c_ulong = 1;
 
-pub const SASL_LOG_NONE: c_uint = 0;
-pub const SASL_LOG_ERR: c_uint = 1;
-pub const SASL_LOG_FAIL: c_uint = 2;
-pub const SASL_LOG_WARN: c_uint = 3;
-pub const SASL_LOG_NOTE: c_uint = 4;
-pub const SASL_LOG_DEBUG: c_uint = 5;
-pub const SASL_LOG_TRACE: c_uint = 6;
-pub const SASL_LOG_PASS: c_uint = 7;
+pub const SASL_LOG_NONE: c_int = 0;
+pub const SASL_LOG_ERR: c_int = 1;
+pub const SASL_LOG_FAIL: c_int = 2;
+pub const SASL_LOG_WARN: c_int = 3;
+pub const SASL_LOG_NOTE: c_int = 4;
+pub const SASL_LOG_DEBUG: c_int = 5;
+pub const SASL_LOG_TRACE: c_int = 6;
+pub const SASL_LOG_PASS: c_int = 7;
 
 pub type sasl_log_t = Option<
     unsafe extern "C" fn(context: *mut c_void, level: c_int, message: *const c_char) -> c_int,


### PR DESCRIPTION
To avoid casting when used with the sasl_log_t typedef.

Fix #40.