### PR TITLE
Fix build on windows

### DIFF
--- a/sasl2-sys/src/iovec.rs
+++ b/sasl2-sys/src/iovec.rs
@@ -1,0 +1,27 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! iovec
+
+#[cfg(not(windows))]
+pub use libc::iovec;
+
+#[cfg(windows)]
+#[allow(dead_code)]
+#[repr(C)]
+pub struct iovec {
+    pub iov_len: libc::c_long,
+    pub iov_base: *mut libc::c_char,
+}

--- a/sasl2-sys/src/lib.rs
+++ b/sasl2-sys/src/lib.rs
@@ -90,6 +90,7 @@
 extern crate openssl_sys;
 
 pub mod hmac_md5;
+pub mod iovec;
 pub mod md5;
 pub mod prop;
 pub mod sasl;

--- a/sasl2-sys/src/sasl.rs
+++ b/sasl2-sys/src/sasl.rs
@@ -15,8 +15,9 @@
 
 //! Main SASL API.
 
-use libc::{c_char, c_int, c_uchar, c_uint, c_ulong, c_void, iovec};
+use libc::{c_char, c_int, c_uchar, c_uint, c_ulong, c_void};
 
+use super::iovec::iovec;
 use super::prop::propctx;
 
 // Version.

--- a/sasl2-sys/src/saslplug.rs
+++ b/sasl2-sys/src/saslplug.rs
@@ -15,9 +15,10 @@
 
 //! SASL plugin API.
 
-use libc::{c_char, c_int, c_uchar, c_uint, c_ulong, c_void, iovec};
+use libc::{c_char, c_int, c_uchar, c_uint, c_ulong, c_void};
 
 use super::hmac_md5::{HMAC_MD5_CTX, HMAC_MD5_STATE};
+use super::iovec::iovec;
 use super::md5::MD5_CTX;
 use super::prop::{propctx, propval};
 use super::sasl::{


### PR DESCRIPTION
iovec is not available in libc on Windows, so define our own.